### PR TITLE
feat: New prosemirror plugin to adapt citation style to language.

### DIFF
--- a/fiduswriter/dhdconf/static/js/modules/dhdconf/editor.js
+++ b/fiduswriter/dhdconf/static/js/modules/dhdconf/editor.js
@@ -4,6 +4,8 @@ import { config } from "./config"
 import { DhdConfHtmlExporter, DhdConfDocxExporter } from "./exporter"
 import { injectCitationStyle } from "./citationstyle"
 
+import { languageCitationSyncPlugin } from "./language_citation"
+
 function showSucces() {
     addAlert("success", gettext("Export finished"))
 }
@@ -16,6 +18,10 @@ function showError(e) {
 export class DhdconfEditor {
     constructor(editor) {
         this.editor = editor
+        this.editor.statePlugins = [
+            [languageCitationSyncPlugin],
+            ...this.editor.statePlugins,
+        ]
     }
 
     async init() {

--- a/fiduswriter/dhdconf/static/js/modules/dhdconf/language_citation.js
+++ b/fiduswriter/dhdconf/static/js/modules/dhdconf/language_citation.js
@@ -1,0 +1,46 @@
+// Theoretically we should put this file in modules/editor/state_plugins/
+// But we would then overwrite the original plugins
+
+// For explanation see:
+// https://github.com/fiduswriter/fiduswriter/issues/1404
+// https://prosemirror.net/docs/ref/
+
+import { Plugin, PluginKey } from "prosemirror-state"
+
+const key = new PluginKey("language_citation")
+
+export const languageCitationSyncPlugin = () => {
+    return new Plugin({
+        key,
+        appendTransaction(transactions, oldState, newState) {
+            const oldLang = oldState.doc.attrs.language
+            const newLang = newState.doc.attrs.language
+
+            // Only react when the language attribute actually changes
+            if (oldLang !== newLang) {
+                let targetCitationStyle
+                if (newLang === "en-US" || newLang === "en-GB") {
+                    targetCitationStyle = "chicago-author-date-16th-edition"
+                } else if (newLang === "de-DE") {
+                    targetCitationStyle = "chicago-author-date-de"
+                }
+
+                // Check if the target differs from what's already in the new state
+                const currentCitationStyle = newState.doc.attrs.citation_style
+                if (
+                    targetCitationStyle !== undefined &&
+                    targetCitationStyle !== currentCitationStyle
+                ) {
+                    // Return a new transaction to update the attribute
+                    return newState.tr.setDocAttribute(
+                        "citation_style",
+                        targetCitationStyle,
+                    )
+                }
+            }
+
+            // No changes needed
+            return null
+        },
+    })
+}


### PR DESCRIPTION
See: https://github.com/fiduswriter/fiduswriter/issues/1404

We should probable put the file
fiduswriter/dhdconf/static/js/modules/dhdconf/language_citation.js in another place. See comment in the file itself!